### PR TITLE
v0.5.4

### DIFF
--- a/examples/app/handlers/orders.completed.js
+++ b/examples/app/handlers/orders.completed.js
@@ -3,6 +3,9 @@ module.exports = function Handler(log) {
     let message = ctx.message
     log.info(message, 'Got a message')
     if (!message.orderId) throw new Error('No orderId')
+    if (message.orderId === 'fail_with_object') {
+      return ctx.failure({ msg: 'failed with object' })
+    }
     if (message.orderId === 'retry') return ctx.retryAfterSec(60)
     ctx.success()
   }

--- a/examples/app/test/handlers_test.js
+++ b/examples/app/test/handlers_test.js
@@ -9,6 +9,11 @@ describe('OrderCompleted', function() {
       await QT.onMessage('orders.completed', { orderId: null })
         .expectFailure('No orderId')
     })
+
+    it('sets body to provided object if not error', async function() {
+      await QT.onMessage('orders.completed', { orderId: 'fail_with_object' })
+        .expectFailure({ msg: 'failed with object' })
+    })
   })
 
   describe('retries', function() {

--- a/lib/http_server/message_context.js
+++ b/lib/http_server/message_context.js
@@ -11,7 +11,11 @@ module.exports = class MessageExtensions {
   }
 
   failure(err, code) {
-    if (err) this.koaCtx.body = err.message
+    if (err) {
+      if (err instanceof Error) {
+        this.koaCtx.body = err.message
+      } else this.koaCtx.body = err
+    }
     this.koaCtx.status = code || 500
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadro",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "keywords": [
     "framework",
     "quadro",


### PR DESCRIPTION
+ In MessageContext.failure() allow passing an arbitrary object instead
of `err`