### PR TITLE
fix bug in jobs - after throwing an error, a job would never run again

### DIFF
--- a/lib/jobs/jobs.js
+++ b/lib/jobs/jobs.js
@@ -20,6 +20,7 @@ module.exports = class {
     let interval = this.getIntervalMillis(job, name)
     return Promise.delay(interval)
       .then(() => this.__registered[name].run())
+      .catch(err => this.log.error({ err, jobName: name }, 'Error while running job'))
       .then(() => this.scheduleJob(job, name))
   }
 


### PR DESCRIPTION
If a job ever threw an error (on any invocation, didn't have to be first), it would never run again and the error message displayed (other than the error itself) would be 'Error registering job'.

After the fix - the error message displayed (other than the error itself) is 'Error while running job' and the job will run again at the next interval