### PR TITLE
Enable disabling of koa-body parser

### DIFF
--- a/lib/http_server/server.js
+++ b/lib/http_server/server.js
@@ -15,10 +15,16 @@ module.exports = class {
   }
 
   async initialize() {
-    const koaBody = require('koa-body')
-    this.koa.use(koaBody({
-      multipart: true
-    }))
+    const enableKoaBodyParser = await this.config.get('quadro.middleware.koa-body', true)
+
+    if (enableKoaBodyParser) {
+      const koaBody = require('koa-body')
+      this.koa.use(
+        koaBody({
+          multipart: true
+        })
+      )
+    }
 
     await this.app.emit('routes-will-load', { quadroHttpServer: this })
 

--- a/lib/http_server/server.js
+++ b/lib/http_server/server.js
@@ -15,7 +15,7 @@ module.exports = class {
   }
 
   async initialize() {
-    const enableKoaBodyParser = await this.config.get('quadro.middleware.koa-body', true)
+    const enableKoaBodyParser = await this.config.get('quadro.middleware.koa-body.enabled', true)
 
     if (enableKoaBodyParser) {
       const koaBody = require('koa-body')


### PR DESCRIPTION
Enable disabling koa-body parser so we can use 

```js
const raw = require('raw-body')
const rawBody = await raw(ctx.req)
```

That's essential for forwarding POST/upload requests in Admin UI backend

If you have any other idea, let me know
