### PR TITLE
hon2a/eslint-optional

### DIFF
--- a/initializers/es_lint.js
+++ b/initializers/es_lint.js
@@ -1,5 +1,6 @@
 module.exports = async function(app, log, config) {
   if (app.env === 'production') return
+  if (await config.get('quadro.eslint') === false) return
 
   log.trace('Running ESLint')
 


### PR DESCRIPTION
The `es_lint` initializer is now optional. This allows the application to use the latest ESLint and plugins without incompatibilities with Quadro, preventing errors as [this one](https://circleci.com/gh/WisePricer/pricing-application/2864?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

_Personally I think the `es_lint` initializer should never have been created, because it's of no concern to the framework, but that applies to a lot of things in here._